### PR TITLE
Remove partial match to `Indicator_VCV` in `R/csem_fit.R`

### DIFF
--- a/R/csem_fit.R
+++ b/R/csem_fit.R
@@ -73,7 +73,7 @@ fit.cSEMResults_default <- function(
   }
   
   mod       <- .object$Information$Model
-  S         <- .object$Estimates$Indicator
+  S         <- .object$Estimates$Indicator_VCV
   Lambda    <- .object$Estimates$Loading_estimates
   Theta     <- diag(diag(S) - diag(t(Lambda) %*% Lambda))
   dimnames(Theta) <- dimnames(S)


### PR DESCRIPTION
Suggested fix for #558.

The example from #558 now runs without a warning:

```r
options(warnPartialMatchDollar = TRUE) # enable partial match warnings
library(cSEM)

## Specify the (correct) model
model <- "
# Structural model
eta2 ~ eta1
eta3 ~ eta1 + eta2

# (Reflective) measurement model
eta1 =~ y11 + y12 + y13
eta2 =~ y21 + y22 + y23
eta3 =~ y31 + y32 + y33
"

## Estimate
res <- csem(threecommonfactors, model)

invisible(capture.output(res)) # no longer gives a warning
```